### PR TITLE
Now highlights function body blocks during execution.

### DIFF
--- a/Blockr/src/com/blockr/domain/block/BlockProgram.java
+++ b/Blockr/src/com/blockr/domain/block/BlockProgram.java
@@ -252,6 +252,11 @@ public class BlockProgram implements ReadOnlyBlockProgram, Cloneable {
         var previous = rwPlugBlock.getPrevious();
         if(previous != null){
             previous.setNext(null);
+        }else{
+            if(blocks.stream().anyMatch(b -> b instanceof FunctionDefinitionBlock)){
+                if(getBlocksOfType(FunctionDefinitionBlock.class).stream().findFirst().get().getFunctionBody().getBody() == rwPlugBlock)
+                    getBlocksOfType(FunctionDefinitionBlock.class).stream().findFirst().get().getFunctionBody().setBody(rwSocketBlock);
+            }
         }
 
         //the (chain) of statementBlock(s) might be inserted between rwSocketBlock and rwSocketBlock.getNext()

--- a/Blockr/src/com/blockr/ui/components/programblocks/PaletteArea.java
+++ b/Blockr/src/com/blockr/ui/components/programblocks/PaletteArea.java
@@ -3,6 +3,7 @@ package com.blockr.ui.components.programblocks;
 import an.awesome.pipelinr.Pipeline;
 import com.blockr.domain.block.*;
 import com.blockr.handlers.actions.record.DoRecord;
+import com.blockr.handlers.blockprogram.getblockprogram.GetBlockProgram;
 import com.blockr.handlers.ui.input.GetProgramSelection;
 import com.blockr.handlers.ui.input.resetuistate.ResetUIState;
 import com.ui.Component;
@@ -24,6 +25,7 @@ public class PaletteArea extends Container {
 
     private static final List<PaletteBlockComponent> programBlockComponents = new ArrayList<>();
     private static final List<WindowPosition> regionPositions = new ArrayList<>();
+    private static PaletteBlockComponent functionComponent;
 
     private final Pipeline mediator;
 
@@ -67,6 +69,7 @@ public class PaletteArea extends Container {
         rootPos = rootPos.plus(new WindowPosition(0,spaceBetween + block_height));
         programBlockComponents.add(new PaletteBlockComponent(new FunctionDefinitionBlock(), mediator, rootPos));
         regionPositions.add(rootPos);
+        functionComponent = programBlockComponents.get(programBlockComponents.size()-1);
     }
 
     public PaletteArea(Pipeline mediator) {
@@ -133,6 +136,10 @@ public class PaletteArea extends Container {
 
     @Override
     protected void draw(Graphics graphics) {
-
+        if(ProgramArea.programHasFunction()){
+            programBlockComponents.remove(functionComponent);
+        }else if(!programBlockComponents.stream().anyMatch(pbc -> pbc.getSource() instanceof FunctionDefinitionBlock)){
+            programBlockComponents.add(functionComponent);
+        }
     }
 }

--- a/Blockr/src/com/blockr/ui/components/programblocks/ProgramArea.java
+++ b/Blockr/src/com/blockr/ui/components/programblocks/ProgramArea.java
@@ -438,4 +438,8 @@ public class ProgramArea extends Container {
         }
         keyPressUtility.Reset();
     }
+
+    protected static boolean programHasFunction(){
+        return programBlockComponents.stream().anyMatch(pbc -> pbc.getSource() instanceof FunctionDefinitionBlock);
+    }
 }

--- a/Blockr/src/com/blockr/ui/components/programblocks/UIBlockComponent.java
+++ b/Blockr/src/com/blockr/ui/components/programblocks/UIBlockComponent.java
@@ -368,7 +368,9 @@ public abstract class UIBlockComponent extends Component {
         }
 
         if(mediator.send(new GetBlockProgram()).getActive() instanceof FunctionDefinitionBlock){
-            if(((FunctionDefinitionBlock) mediator.send(new GetBlockProgram()).getActive()).getCurrent() == source){
+            if(((FunctionDefinitionBlock) mediator.send(new GetBlockProgram()).getActive()).getCurrent() == source
+            || (((FunctionDefinitionBlock) mediator.send(new GetBlockProgram()).getActive()).getCurrent() == null
+            && ((FunctionDefinitionBlock) mediator.send(new GetBlockProgram()).getActive()).getFunctionBody().getBody() == this.source) ){
                 graphics.setColor(Color.PINK);
                 graphics.fillRect(0, 0, getWidth(source), getHeight(source));
                 graphics.setColor(Color.yellow);


### PR DESCRIPTION
--> Small fix
Fixed a bug when adding a new block to the top of Function Body block.

Function Definition Blocks now disappear from the Palette if a Function Definition is already present in the Program Area.